### PR TITLE
Add field warning to SearchResponse

### DIFF
--- a/src/main/java/com/manticoresearch/client/model/SearchResponse.java
+++ b/src/main/java/com/manticoresearch/client/model/SearchResponse.java
@@ -9,23 +9,12 @@
 package com.manticoresearch.client.model;
 
 import java.util.Objects;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.manticoresearch.client.model.SearchResponseHits;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.manticoresearch.client.JSON;
-
 
 /**
  * Response object of a search request

--- a/src/main/java/com/manticoresearch/client/model/SearchResponse.java
+++ b/src/main/java/com/manticoresearch/client/model/SearchResponse.java
@@ -36,7 +36,8 @@ import com.manticoresearch.client.JSON;
   SearchResponse.JSON_PROPERTY_TIMED_OUT,
   SearchResponse.JSON_PROPERTY_AGGREGATIONS,
   SearchResponse.JSON_PROPERTY_HITS,
-  SearchResponse.JSON_PROPERTY_PROFILE
+  SearchResponse.JSON_PROPERTY_PROFILE,
+  SearchResponse.JSON_PROPERTY_WARNING
 })
 
 public class SearchResponse {
@@ -54,7 +55,9 @@ public class SearchResponse {
 
   public static final String JSON_PROPERTY_PROFILE = "profile";
   private Object profile;
-
+  
+  public static final String JSON_PROPERTY_WARNING = "warning";
+  private Map<String, Object> warning;
 
   public SearchResponse took(Integer took) {
     this.took = took;
@@ -174,8 +177,24 @@ public class SearchResponse {
   public void setProfile(Object profile) {
     this.profile = profile;
   }
+  
+   /**
+   * Get warning
+   * @return warning
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WARNING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
+  public Map<String, Object> getWarning() {
+    return warning;
+  }
 
+  public void setWarning(Map<String, Object> warning) {
+     this.warning = warning;
+  }
+  
   /**
    * Return true if this searchResponse object is equal to o.
    */

--- a/src/test/java/com/manticoresearch/client/model/SearchResponseTest.java
+++ b/src/test/java/com/manticoresearch/client/model/SearchResponseTest.java
@@ -78,4 +78,12 @@ public class SearchResponseTest {
         // TODO: test profile
     }
 
+    /**
+     * Test the property 'warning'
+     */
+    @Test
+    public void warningTest() {
+        // TODO: test warning
+    }
+
 }


### PR DESCRIPTION
Deserialization of SearchResponse fails with:

Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "warning" (class com.manticoresearch.client.model.SearchResponse), not marked as ignorable (4 known properties: "hits", "profile", "timed_out", "took"])

without warning field in SearchResponse.

This PR adds the missing field(property).